### PR TITLE
WIFI-797 RF SourceSelection

### DIFF
--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/OpensyncExternalIntegrationCloud.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/OpensyncExternalIntegrationCloud.java
@@ -1066,7 +1066,7 @@ public class OpensyncExternalIntegrationCloud implements OpensyncExternalIntegra
 	                	.setEirpTxPower(SourceSelectionValue.createAutomaticInstance(radioState.getTxPower()));
             	} else if (txPowerSource == SourceType.profile) {
 	                apElementConfiguration.getRadioMap().get(radioState.getFreqBand())
-                    	.setEirpTxPower(SourceSelectionValue.createProfileInstance(radioState.getTxPower()));
+	                	.setEirpTxPower(SourceSelectionValue.createProfileInstance(radioState.getTxPower()));
             	} else {
 	                apElementConfiguration.getRadioMap().get(radioState.getFreqBand())
 	                	.setEirpTxPower(SourceSelectionValue.createManualInstance(radioState.getTxPower()));

--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/OpensyncExternalIntegrationCloud.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/OpensyncExternalIntegrationCloud.java
@@ -30,7 +30,6 @@ import com.telecominfraproject.wlan.client.session.models.ClientDhcpDetails;
 import com.telecominfraproject.wlan.client.session.models.ClientSession;
 import com.telecominfraproject.wlan.client.session.models.ClientSessionDetails;
 import com.telecominfraproject.wlan.core.model.entity.CountryCode;
-import com.telecominfraproject.wlan.core.model.equipment.AutoOrManualValue;
 import com.telecominfraproject.wlan.core.model.equipment.EquipmentType;
 import com.telecominfraproject.wlan.core.model.equipment.MacAddress;
 import com.telecominfraproject.wlan.core.model.equipment.RadioType;

--- a/opensync-ext-static/src/main/resources/EquipmentExample.json
+++ b/opensync-ext-static/src/main/resources/EquipmentExample.json
@@ -38,37 +38,28 @@
         "channelNumber": 6,
         "manualChannelNumber": 6,
         "backupChannelNumber": 11,
-        "autoChannelSelection": false,
-        "channelBandwidth": "is20MHz",
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
-        "bestApEnabled": null,
-        "neighbouringListApConfig": {
-          "model_type": "NeighbouringAPListConfiguration",
-          "minSignal": -85,
-          "maxAps": 25
-        },
-        "minAutoCellSize": -80,
         "perimeterDetectionEnabled": true,
         "bestAPSteerType": "both",
         "deauthAttackDetection": null,
@@ -81,37 +72,28 @@
         "channelNumber": 149,
         "manualChannelNumber": 149,
         "backupChannelNumber": 154,
-        "autoChannelSelection": false,
-        "channelBandwidth": "is80MHz",
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
-        "bestApEnabled": null,
-        "neighbouringListApConfig": {
-          "model_type": "NeighbouringAPListConfiguration",
-          "minSignal": -85,
-          "maxAps": 25
-        },
-        "minAutoCellSize": -80,
         "perimeterDetectionEnabled": true,
         "bestAPSteerType": "both",
         "deauthAttackDetection": null,
@@ -124,37 +106,28 @@
         "channelNumber": 36,
         "manualChannelNumber": 36,
         "backupChannelNumber": 44,
-        "autoChannelSelection": false,
-        "channelBandwidth": "is80MHz",
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
-        "bestApEnabled": null,
-        "neighbouringListApConfig": {
-          "model_type": "NeighbouringAPListConfiguration",
-          "minSignal": -85,
-          "maxAps": 25
-        },
-        "minAutoCellSize": -80,
         "perimeterDetectionEnabled": true,
         "bestAPSteerType": "both",
         "deauthAttackDetection": null,
@@ -168,39 +141,25 @@
         "radioType": "is2dot4GHz",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "rtsCtsThreshold": 65535,
-        "autoChannelSelection": "disabled",
-        "radioMode": "modeN",
-        "mimoMode": "twoByTwo",
         "wmmState": "enabled",
         "uapsdState": "enabled",
-        "maxNumClients": 100,
         "stationIsolation": "disabled",
-        "multicastRate": "auto",
-        "managementRate": "auto",
-        "activeScanSettings": {
-          "model_type": "ActiveScanSettings",
-          "enabled": true,
-          "scanFrequencySeconds": 10,
-          "scanDurationMillis": 65
-        },
-        "channelHopSettings": {
-          "model_type": "ChannelHopSettings",
-          "noiseFloorThresholdInDB": -75,
-          "noiseFloorThresholdTimeInSeconds": 180,
-          "nonWifiThresholdInPercentage": 50,
-          "nonWifiThresholdTimeInSeconds": 180,
-          "obssHopMode": "NON_WIFI"
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
         },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 20,
-          "minLoadFactor": 50
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
-        "forceScanDuringVoice": "disabled",
         "legacyBSSRate": "enabled",
-        "beaconInterval": 100,
         "deauthAttackDetection": null
       },
       "is5GHzU": {
@@ -208,39 +167,25 @@
         "radioType": "is5GHzU",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "rtsCtsThreshold": 65535,
-        "autoChannelSelection": "disabled",
-        "radioMode": "modeAC",
-        "mimoMode": "twoByTwo",
         "wmmState": "enabled",
         "uapsdState": "enabled",
-        "maxNumClients": 100,
         "stationIsolation": "disabled",
-        "multicastRate": "auto",
-        "managementRate": "auto",
-        "activeScanSettings": {
-          "model_type": "ActiveScanSettings",
-          "enabled": true,
-          "scanFrequencySeconds": 10,
-          "scanDurationMillis": 65
-        },
-        "channelHopSettings": {
-          "model_type": "ChannelHopSettings",
-          "noiseFloorThresholdInDB": -75,
-          "noiseFloorThresholdTimeInSeconds": 180,
-          "nonWifiThresholdInPercentage": 50,
-          "nonWifiThresholdTimeInSeconds": 180,
-          "obssHopMode": "NON_WIFI"
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
         },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
-        "forceScanDuringVoice": "disabled",
         "legacyBSSRate": "enabled",
-        "beaconInterval": 100,
         "deauthAttackDetection": null
       },
       "is5GHzL": {
@@ -248,39 +193,25 @@
         "radioType": "is5GHzL",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "rtsCtsThreshold": 65535,
-        "autoChannelSelection": "disabled",
-        "radioMode": "modeAC",
-        "mimoMode": "twoByTwo",
         "wmmState": "enabled",
         "uapsdState": "enabled",
-        "maxNumClients": 100,
         "stationIsolation": "disabled",
-        "multicastRate": "auto",
-        "managementRate": "auto",
-        "activeScanSettings": {
-          "model_type": "ActiveScanSettings",
-          "enabled": true,
-          "scanFrequencySeconds": 10,
-          "scanDurationMillis": 65
-        },
-        "channelHopSettings": {
-          "model_type": "ChannelHopSettings",
-          "noiseFloorThresholdInDB": -75,
-          "noiseFloorThresholdTimeInSeconds": 180,
-          "nonWifiThresholdInPercentage": 50,
-          "nonWifiThresholdTimeInSeconds": 180,
-          "obssHopMode": "NON_WIFI"
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
         },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
-        "forceScanDuringVoice": "disabled",
         "legacyBSSRate": "enabled",
-        "beaconInterval": 100,
         "deauthAttackDetection": null
       }
     }

--- a/opensync-ext-static/src/main/resources/ProfileRf.json
+++ b/opensync-ext-static/src/main/resources/ProfileRf.json
@@ -10,6 +10,8 @@
             "is5GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHz",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -25,26 +27,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -65,11 +51,14 @@
                     "mlComputed": true,
                     "dropInSnrPercentage": 30,
                     "minLoadFactor": 40
-                }
+                },
+                "minAutoCellSize": -65
             },
             "is2dot4GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is2dot4GHz",
+                "radioMode": "modeN",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -85,26 +74,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -125,11 +98,14 @@
                     "mlComputed": true,
                     "dropInSnrPercentage": 20,
                     "minLoadFactor": 50
-                }
+                },
+                "minAutoCellSize": -65
             },
             "is5GHzU": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzU",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -145,26 +121,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -185,11 +145,14 @@
                     "mlComputed": true,
                     "dropInSnrPercentage": 30,
                     "minLoadFactor": 40
-                }
+                },
+                "minAutoCellSize": -65
             },
             "is5GHzL": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzL",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -205,26 +168,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -245,7 +192,8 @@
                     "mlComputed": true,
                     "dropInSnrPercentage": 30,
                     "minLoadFactor": 40
-                }
+                },
+                "minAutoCellSize": -65
             }
         },
         "profileType": "rf"

--- a/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/EquipmentExample.json
+++ b/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/EquipmentExample.json
@@ -41,23 +41,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -75,23 +75,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -109,23 +109,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -141,16 +141,23 @@
         "radioType": "is2dot4GHz",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeN",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 20,
-          "minLoadFactor": 50
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -160,16 +167,23 @@
         "radioType": "is5GHzU",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -179,16 +193,23 @@
         "radioType": "is5GHzL",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null

--- a/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/ProfileRf.json
+++ b/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/ProfileRf.json
@@ -10,6 +10,8 @@
             "is5GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHz",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -25,26 +27,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -71,6 +57,8 @@
             "is2dot4GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is2dot4GHz",
+                "radioMode": "modeN",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -86,26 +74,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -132,6 +104,8 @@
             "is5GHzU": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzU",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -147,26 +121,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -193,6 +151,8 @@
             "is5GHzL": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzL",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -208,26 +168,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",

--- a/opensync-gateway-static-docker/src/main/docker/app/opensync/EquipmentExample.json
+++ b/opensync-gateway-static-docker/src/main/docker/app/opensync/EquipmentExample.json
@@ -41,23 +41,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -75,23 +75,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -109,23 +109,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -141,16 +141,23 @@
         "radioType": "is2dot4GHz",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeN",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 20,
-          "minLoadFactor": 50
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -160,16 +167,23 @@
         "radioType": "is5GHzU",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -179,16 +193,23 @@
         "radioType": "is5GHzL",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null

--- a/opensync-gateway-static-docker/src/main/docker/app/opensync/ProfileRf.json
+++ b/opensync-gateway-static-docker/src/main/docker/app/opensync/ProfileRf.json
@@ -10,6 +10,8 @@
             "is5GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHz",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -25,26 +27,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -71,6 +57,8 @@
             "is2dot4GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is2dot4GHz",
+                "radioMode": "modeN",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -86,26 +74,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -132,6 +104,8 @@
             "is5GHzU": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzU",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -147,26 +121,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -193,6 +151,8 @@
             "is5GHzL": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzL",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -208,26 +168,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",

--- a/opensync-gateway-static-process/src/main/resources/app/opensync/EquipmentExample.json
+++ b/opensync-gateway-static-process/src/main/resources/app/opensync/EquipmentExample.json
@@ -41,23 +41,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -75,23 +75,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -109,23 +109,23 @@
         "bannedChannels": [],
         "allowedChannels": [],
         "rxCellSizeDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "probeResponseThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "clientDisconnectThresholdDb": {
-          "model_type": "AutoOrManualValue",
-          "auto": true,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": -90
         },
         "eirpTxPower": {
-          "model_type": "AutoOrManualValue",
-          "auto": false,
+          "model_type": "SourceSelectionValue",
+        	 "source": "auto",
           "value": 32
         },
         "perimeterDetectionEnabled": true,
@@ -141,16 +141,23 @@
         "radioType": "is2dot4GHz",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeN",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 20,
-          "minLoadFactor": 50
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -160,16 +167,23 @@
         "radioType": "is5GHzU",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null
@@ -179,16 +193,23 @@
         "radioType": "is5GHzL",
         "radioAdminState": "enabled",
         "fragmentationThresholdBytes": 2346,
-        "radioMode": "modeAC",
         "wmmState": "enabled",
         "uapsdState": "enabled",
         "stationIsolation": "disabled",
-        "managementRate": "auto",
+        "managementRate": {
+          "model_type": "SourceSelectionManagement",
+          "source": "auto",
+          "value": "auto"
+        },
         "bestApSettings": {
-          "model_type": "RadioBestApSettings",
-          "mlComputed": true,
-          "dropInSnrPercentage": 30,
-          "minLoadFactor": 40
+        "model_type": "SourceSelectionSteering",
+          "source": "auto",
+          "value": {
+	          "model_type": "RadioBestApSettings",
+	          "mlComputed": true,
+	          "dropInSnrPercentage": 30,
+	          "minLoadFactor": 40
+          }
         },
         "legacyBSSRate": "enabled",
         "deauthAttackDetection": null

--- a/opensync-gateway-static-process/src/main/resources/app/opensync/ProfileRf.json
+++ b/opensync-gateway-static-process/src/main/resources/app/opensync/ProfileRf.json
@@ -10,6 +10,8 @@
             "is5GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHz",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -25,26 +27,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -71,6 +57,8 @@
             "is2dot4GHz": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is2dot4GHz",
+                "radioMode": "modeN",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -86,26 +74,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -132,6 +104,8 @@
             "is5GHzU": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzU",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -147,26 +121,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",
@@ -193,6 +151,8 @@
             "is5GHzL": {
                 "model_type": "RfElementConfiguration",
                 "rf": "TipWlan-rf",
+                "radioType": "is5GHzL",
+                "radioMode": "modeAC",
                 "beaconInterval": 100,
                 "forceScanDuringVoice": "disabled",
                 "rtsCtsThreshold": 65535,
@@ -208,26 +168,10 @@
                     "scanDurationMillis": 65
                 },
                 "managementRate": "auto",
-                "rxCellSizeDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "probeResponseThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "clientDisconnectThresholdDb": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": -90
-                },
-                "eirpTxPower": {
-                    "model_type": "AutoOrManualValue",
-                    "auto": true,
-                    "value": 18
-                },
+                "rxCellSizeDb": -90,
+                "probeResponseThresholdDb": -90,
+                "clientDisconnectThresholdDb": -90,
+                "eirpTxPower": 18,
                 "bestApEnabled": null,
                 "neighbouringListApConfig": {
                     "model_type": "NeighbouringAPListConfiguration",

--- a/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbDao.java
+++ b/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbDao.java
@@ -4733,7 +4733,10 @@ public class OvsdbDao {
             } else if (radioType == RadioType.is5GHz) {
                 freqBand = "5G";
             }
-
+            
+            if (rfConfig == null) {
+            	continue;
+            }
             
             ElementRadioConfiguration elementRadioConfig = apElementConfig.getRadioMap().get(radioType);
             RfElementConfiguration rfElementConfig = rfConfig.getRfConfig(radioType);


### PR DESCRIPTION
Main SourceSelection logic change in OpensyncExternalIntergrationCloud and OvsdbDao. 

- Removed the use of RF profile to initialize the ApElementConfiguration RRM parameters
- RRM parameters in ApElementConfig will be set to SourceType.profile by default (in wlan-cloud-services PR)
- OvsdbDao configureWifiRrm will get RRM values based on SourceType. 
- Cleaned up some of the static jsons to more accurately reflect what is in ApElementConfiguration

wlan-cloud-services PR : https://github.com/Telecominfraproject/wlan-cloud-services/pull/32