### PR TITLE
Feature/NETEXP 485

### DIFF
--- a/opensync-gateway-cloud-docker/pom.xml
+++ b/opensync-gateway-cloud-docker/pom.xml
@@ -38,7 +38,7 @@
 					<apiVersion>1.23</apiVersion>
 					<images>
 						<image>
-							<name>opensync-gateway-cloud:${project.version}</name>
+							<name>opensync-gateway-cloud:${project.version}-Testing</name>
 							<build>
 								<tags>
 									<tag>${project.version}-${timestamp}</tag>

--- a/opensync-gateway-cloud-docker/pom.xml
+++ b/opensync-gateway-cloud-docker/pom.xml
@@ -38,7 +38,7 @@
 					<apiVersion>1.23</apiVersion>
 					<images>
 						<image>
-							<name>opensync-gateway-cloud:${project.version}-Testing</name>
+							<name>opensync-gateway-cloud:${project.version}</name>
 							<build>
 								<tags>
 									<tag>${project.version}-${timestamp}</tag>

--- a/opensync-gateway-cloud-docker/src/main/docker/app/run.sh
+++ b/opensync-gateway-cloud-docker/src/main/docker/app/run.sh
@@ -20,6 +20,11 @@ SSC_SERVER_HOST="${SSC_SERVER}"
 ALL_IN_ONE_HOST="${INTEGRATED_SERVER}"
 FILE_STORE_DIRECTORY="${FILE_STORE_DIRECTORY_INTERNAL:=/tmp/filestore}"
 FILE_STORE_EXTERNAL_URL="${FILE_STORE_URL}"
+MQTT_BROKER_EXTERNAL_PORT="${MQTT_BROKER_EXTERNAL_PORT}"
+OVSDB_EXTERNAL_PORT="${OVSDB_EXTERNAL_PORT}"
+
+
+
 
 OVSDB_PROPS=" "
 OVSDB_PROPS+=" -Dtip.wlan.ovsdb.managerAddr=$OVSDB_MANAGER_HOST"
@@ -33,6 +38,8 @@ OVSDB_PROPS+=" -Dtip.wlan.ovsdb.configFileName=/app/opensync/config_2_ssids.json
 MQTT_PROPS=" "
 MQTT_PROPS+=" -Dtip.wlan.mqttBroker.address.internal=$MQTT_BROKER_HOST_INTERNAL"
 MQTT_PROPS+=" -Dtip.wlan.mqttBroker.address.external=$MQTT_BROKER_HOST_EXTERNAL"
+MQTT_PROPS+=" -Dtip.wlan.ovsdb.externalPort=$OVSDB_EXTERNAL_PORT"
+MQTT_PROPS+=" -Dtip.wlan.mqttBroker.externalPort=$MQTT_BROKER_EXTERNAL_PORT"
 MQTT_PROPS+=" -Dtip.wlan.mqttBroker.listenPort=1883"
 
 LOGBACK_CONFIG_FILE="${LOGBACK_CONFIG_FILE:=/app/opensync/logback.xml}"

--- a/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbDao.java
+++ b/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbDao.java
@@ -141,12 +141,18 @@ public class OvsdbDao {
 
     @org.springframework.beans.factory.annotation.Value("${tip.wlan.ovsdb.listenPort:6640}")
     private int ovsdbListenPort;
+    
+    @org.springframework.beans.factory.annotation.Value("${tip.wlan.ovsdb.externalPort:6640}")
+    private int ovsdbExternalPort;
 
     @org.springframework.beans.factory.annotation.Value("${tip.wlan.mqttBroker.address.external:testportal.123wlan.com}")
     private String mqttBrokerAddress;
 
     @org.springframework.beans.factory.annotation.Value("${tip.wlan.mqttBroker.listenPort:1883}")
     private int mqttBrokerListenPort;
+    
+    @org.springframework.beans.factory.annotation.Value("${tip.wlan.mqttBroker.externalPort:1883}")
+    private int mqttBrokerExternalPort;
 
     @org.springframework.beans.factory.annotation.Value("${tip.wlan.ovsdb.timeoutSec:30}")
     private int ovsdbTimeoutSec;
@@ -565,7 +571,7 @@ public class OvsdbDao {
             String mqttClientName = OvsdbToWlanCloudTypeMappingUtility.getAlteredClientCnIfRequired(clientCn,
                     incomingConnectNodeInfo, preventCnAlteration);
             newMqttSettings.put("topics", "/ap/" + mqttClientName + "/opensync");
-            newMqttSettings.put("port", "" + mqttBrokerListenPort);
+            newMqttSettings.put("port", "" + mqttBrokerExternalPort);
             newMqttSettings.put("compress", "zlib");
             newMqttSettings.put("qos", "0");
             newMqttSettings.put("remote_log", "1");
@@ -777,7 +783,7 @@ public class OvsdbDao {
             operations.clear();
             Map<String, Value> updateColumns = new HashMap<>();
 
-            updateColumns.put("manager_addr", new Atom<>("ssl:" + managerIpAddr + ":" + ovsdbListenPort));
+            updateColumns.put("manager_addr", new Atom<>("ssl:" + managerIpAddr + ":" + ovsdbExternalPort));
 
             row = new Row(updateColumns);
             operations.add(new Update(awlanNodeDbTable, row));


### PR DESCRIPTION
Added separate variables for manager_addr port and mqtt_settings port
that are displayed in the AWLAN table. The default values are 1883 and
6640, but these can be overridden in the helm charts based on customer
requirements. For the respective helm chart changes, please refer https://github.com/Telecominfraproject/wlan-cloud-helm/pull/22 

Output after the changes (overriding the external ports to use 443 using the helm override file):

![image](https://user-images.githubusercontent.com/66637665/99315813-3c977700-2831-11eb-869a-8f354f6361d2.png)

