### PR TITLE
docker-opensync-gateway-and-mqtt: ProfileVenue: fix

### DIFF
--- a/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/ProfileVenue.json
+++ b/opensync-gateway-static-docker/src/main/docker-opensync-gateway-and-mqtt/app/opensync/ProfileVenue.json
@@ -28,7 +28,7 @@
 				}
 			],
 			"venueTypeAssignment": {
-				"model_type": "ProfileVenueTypeAssignment",
+				"model_type": "PasspointVenueTypeAssignment",
 				"venueDescription": "Research and Development Facility",
 				"venueGroupId": 2,
 				"venueTypeId": 8


### PR DESCRIPTION
If run docker with OpenSync GW and MQTT broker inside and allow
board Linksys EA8300 connect it then next error occure in OpenSync GW

Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException:
Could not resolve type id 'ProfileVenueTypeAssignment' as a subtype of
`com.telecominfraproject.wlan.profile.passpoint.models.venue.Passpoint
VenueTypeAssignment`: known type ids = [PasspointVenueTypeAssignment]
(for POJO property 'venueTypeAssignment')

Change in ProfileVenue.json the property "venueTypeAssignment.modelType"
value
  from
    "ProfileVenueTypeAssignment"
  to
    "PasspointVenueTypeAssignment"

Signed-off-by: Ivan Efimov <i.efimov@inango-systems.com>