### PR TITLE
Move the raising and clearing of the threshold alarms into the gatewa…

### DIFF
--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
@@ -989,7 +989,9 @@ public class MqttStatsPublisher {
             if (deviceReport.hasMemUtil() && deviceReport.getMemUtil().hasMemTotal() && deviceReport.getMemUtil().hasMemUsed()) {
                 apPerformance.setFreeMemory(deviceReport.getMemUtil().getMemTotal() - deviceReport.getMemUtil().getMemUsed());
 
-                if (deviceReport.getMemUtil().getMemUsed()/deviceReport.getMemUtil().getMemTotal() * 100 > memoryUtilThresholdPct) {
+                double usedMemory = deviceReport.getMemUtil().getMemUsed();
+                double totalMemory = deviceReport.getMemUtil().getMemTotal();
+                if (usedMemory/totalMemory * 100 > memoryUtilThresholdPct) {
                     raiseDeviceThresholdAlarm(customerId, equipmentId, AlarmCode.MemoryUtilization, deviceReport.getTimestampMs());
                 } else {
                     // Clear any existing cpuUtilization alarms

--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
@@ -989,7 +989,7 @@ public class MqttStatsPublisher {
             if (deviceReport.hasMemUtil() && deviceReport.getMemUtil().hasMemTotal() && deviceReport.getMemUtil().hasMemUsed()) {
                 apPerformance.setFreeMemory(deviceReport.getMemUtil().getMemTotal() - deviceReport.getMemUtil().getMemUsed());
 
-                if (deviceReport.getMemUtil().getMemUsed()/deviceReport.getMemUtil().getMemTotal() > memoryUtilThresholdPct) {
+                if (deviceReport.getMemUtil().getMemUsed()/deviceReport.getMemUtil().getMemTotal() * 100 > memoryUtilThresholdPct) {
                     raiseDeviceThresholdAlarm(customerId, equipmentId, AlarmCode.MemoryUtilization, deviceReport.getTimestampMs());
                 } else {
                     // Clear any existing cpuUtilization alarms

--- a/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbSsidConfig.java
+++ b/opensync-gateway/src/main/java/com/telecominfraproject/wlan/opensync/ovsdb/dao/OvsdbSsidConfig.java
@@ -643,10 +643,8 @@ public class OvsdbSsidConfig extends OvsdbDaoBase {
                 if ((ssidConfig.getCaptivePortalId() == profileCaptive.getId()) && (profileCaptive.getDetails() != null)) {
                     CaptivePortalConfiguration captiveProfileDetails = ((CaptivePortalConfiguration) profileCaptive.getDetails());
 
-                    // +#define SCHEMA_CONSTS_PAGE_TITLE "page_title"
                     if (captiveProfileDetails.getBrowserTitle() != null) {
                         captiveMap.put("session_timeout", String.valueOf(captiveProfileDetails.getSessionTimeoutInMinutes()));
-                        captiveMap.put("page_title", captiveProfileDetails.getBrowserTitle());
                     }
                     if (captiveProfileDetails.getAuthenticationType().equals(CaptivePortalAuthenticationType.radius)) {
                         Optional<Profile> optional =


### PR DESCRIPTION
Move the raising and clearing of the threshold alarms into the gateway controller when the device information is received in the MQTT device report. Update EquipmentAdminState alarms or clear if required.

Signed-off-by: Mike Hansen <mike.hansen@connectus.ai>