### PR TITLE
WIFI-3216 Made the service metrics' timestamps 0 so that the CloudEventDispatcherController can assign unique time stamps

### DIFF
--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
@@ -209,10 +209,10 @@ public class MqttStatsPublisher implements StatsPublisherInterface {
             if (!metricRecordList.isEmpty()) {
                 long serviceMetricTimestamp = System.currentTimeMillis();
                 metricRecordList.stream().forEach(smr -> {  
-                	// TODO use serviceMetricTimestamp rather than 0. This is done for now since there are some
+                	// TODO use serviceMetricTimestamp instead. This is done for now since there are some
                 	// channel metrics that have overlapping keys which messes up Cassandra if the same time stamp 
-                	// is used and setting it to 0 allows the CloudEventDispatcherController to assign unique time stamps. 
-                    smr.setCreatedTimestamp(0);
+                	// is used. This should allow for unique time stamps. 
+                    smr.setCreatedTimestamp(System.currentTimeMillis());
                     if (smr.getLocationId() == 0)
                         smr.setLocationId(locationId);
                     if (smr.getCustomerId() == 0)

--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
@@ -208,8 +208,11 @@ public class MqttStatsPublisher implements StatsPublisherInterface {
 
             if (!metricRecordList.isEmpty()) {
                 long serviceMetricTimestamp = System.currentTimeMillis();
-                metricRecordList.stream().forEach(smr -> {              
-                    smr.setCreatedTimestamp(serviceMetricTimestamp);
+                metricRecordList.stream().forEach(smr -> {  
+                	// TODO use serviceMetricTimestamp rather than 0. This is done for now since there are some
+                	// channel metrics that have overlapping keys which messes up Cassandra if the same time stamp 
+                	// is used and setting it to 0 allows the CloudEventDispatcherController to assign unique time stamps. 
+                    smr.setCreatedTimestamp(0);
                     if (smr.getLocationId() == 0)
                         smr.setLocationId(locationId);
                     if (smr.getCustomerId() == 0)

--- a/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
+++ b/opensync-ext-cloud/src/main/java/com/telecominfraproject/wlan/opensync/external/integration/utils/MqttStatsPublisher.java
@@ -209,10 +209,10 @@ public class MqttStatsPublisher implements StatsPublisherInterface {
             if (!metricRecordList.isEmpty()) {
                 long serviceMetricTimestamp = System.currentTimeMillis();
                 metricRecordList.stream().forEach(smr -> {  
-                	// TODO use serviceMetricTimestamp instead. This is done for now since there are some
-                	// channel metrics that have overlapping keys which messes up Cassandra if the same time stamp 
-                	// is used. This should allow for unique time stamps. 
-                    smr.setCreatedTimestamp(System.currentTimeMillis());
+                	// TODO use serviceMetricTimestamp rather than 0. This is done for now since there are some
+                	// channel metrics that have overlapping keys which messes up Cassandra if the same time stamp is used
+                	// and setting it to 0 allows the CloudEventDispatcherController to assign unique time stamps. 
+                    smr.setCreatedTimestamp(0);
                     if (smr.getLocationId() == 0)
                         smr.setLocationId(locationId);
                     if (smr.getCustomerId() == 0)


### PR DESCRIPTION
There are times where two separate channel service metrics (one with each radio type) have the same timestamp which  makes them have the same primary keys. This causes a collision in Cassandra and only one is kept. This is will be kept until ServiceMetrics can be stored in ElasticSearch.